### PR TITLE
Swdev 409738 review

### DIFF
--- a/library/src/include/rocblas.hpp
+++ b/library/src/include/rocblas.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1879,40 +1879,32 @@ rocblas_status rocblasCall_trsv(rocblas_handle handle,
 
 // trsm memory sizes
 template <bool BATCHED, typename T>
-void rocblasCall_trsm_mem(rocblas_side side,
-                          rocblas_operation transA,
-                          rocblas_int m,
-                          rocblas_int n,
-                          rocblas_int batch_count,
-                          size_t* x_temp,
-                          size_t* x_temp_arr,
-                          size_t* invA,
-                          size_t* invA_arr)
+rocblas_status rocblasCall_trsm_mem(rocblas_side side,
+                                    rocblas_operation transA,
+                                    rocblas_int m,
+                                    rocblas_int n,
+                                    rocblas_int batch_count,
+                                    size_t* x_temp,
+                                    size_t* x_temp_arr,
+                                    size_t* invA,
+                                    size_t* invA_arr)
 {
-    assert(x_temp != nullptr);
-    assert(x_temp_arr != nullptr);
-    assert(invA != nullptr);
-    assert(invA_arr != nullptr);
-
     size_t no_opt_size = 0;
     /** TODO: For now, we always request the size for optimal performance.
         no_opt_size could be used in the future if we generalize the use of
         rocblas_workmode parameter **/
 
     // can't infer batched based on input params
-    rocblas_status istat = rocblas_status_success;
     if constexpr(BATCHED)
     {
-        istat = (rocblas_internal_trsm_batched_workspace_size<T>(
-            side, transA, m, n, batch_count, 0, x_temp, x_temp_arr, invA, invA_arr, &no_opt_size));
+        return rocblas_internal_trsm_batched_workspace_size<T>(
+            side, transA, m, n, batch_count, 0, x_temp, x_temp_arr, invA, invA_arr, &no_opt_size);
     }
     else
     {
-        istat = (rocblas_internal_trsm_workspace_size<T>(side, transA, m, n, batch_count, 0, x_temp,
-                                                         x_temp_arr, invA, invA_arr, &no_opt_size));
+        return rocblas_internal_trsm_workspace_size<T>(side, transA, m, n, batch_count, 0, x_temp,
+                                                       x_temp_arr, invA, invA_arr, &no_opt_size);
     }
-
-    assert((istat == rocblas_status_success) || (istat == rocblas_status_continue));
 }
 
 // trsm

--- a/library/src/include/rocsolver_run_specialized_kernels.hpp
+++ b/library/src/include/rocsolver_run_specialized_kernels.hpp
@@ -40,19 +40,19 @@
 
 // trsm
 template <bool BATCHED, bool STRIDED, typename T>
-void rocsolver_trsm_mem(const rocblas_side side,
-                        const rocblas_operation trans,
-                        const rocblas_int m,
-                        const rocblas_int n,
-                        const rocblas_int batch_count,
-                        size_t* size_work1,
-                        size_t* size_work2,
-                        size_t* size_work3,
-                        size_t* size_work4,
-                        bool* optim_mem,
-                        bool inblocked = false,
-                        const rocblas_int inca = 1,
-                        const rocblas_int incb = 1);
+rocblas_status rocsolver_trsm_mem(const rocblas_side side,
+                                  const rocblas_operation trans,
+                                  const rocblas_int m,
+                                  const rocblas_int n,
+                                  const rocblas_int batch_count,
+                                  size_t* size_work1,
+                                  size_t* size_work2,
+                                  size_t* size_work3,
+                                  size_t* size_work4,
+                                  bool* optim_mem,
+                                  bool inblocked = false,
+                                  const rocblas_int inca = 1,
+                                  const rocblas_int incb = 1);
 
 template <bool BATCHED, bool STRIDED, typename T, typename U>
 rocblas_status rocsolver_trsm_lower(rocblas_handle handle,

--- a/library/src/lapack/roclapack_potf2.hpp
+++ b/library/src/lapack/roclapack_potf2.hpp
@@ -115,6 +115,14 @@ void rocsolver_potf2_getMemorySize(const rocblas_int n,
         return;
     }
 
+    if(n <= POTRF_BLOCKSIZE(T))
+    {
+        *size_scalars = 0;
+        *size_work = 0;
+        *size_pivots = 0;
+        return;
+    }
+
     // size of scalars (constants)
     *size_scalars = sizeof(T) * 3;
 

--- a/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -36,23 +36,6 @@
 #include <algorithm>
 #include <cmath>
 
-__device__ static double rocsolver_conj(double x)
-{
-    return (x);
-}
-__device__ static float rocsolver_conj(float x)
-{
-    return (x);
-}
-__device__ static rocblas_double_complex rocsolver_conj(rocblas_double_complex x)
-{
-    return (std::conj(x));
-}
-__device__ static rocblas_float_complex rocsolver_conj(rocblas_float_complex x)
-{
-    return (std::conj(x));
-}
-
 /**
  * indexing for packed storage
  * for upper triangular
@@ -167,7 +150,7 @@ __device__ static void potf2_simple(bool const is_upper, I const n, T* const A, 
             //   (2) vl21 * l11' = va21 =>  vl21 = va21/ l11', scale vector
             // ------------------------------------------------------------
 
-            auto const conj_lkk = rocsolver_conj(lkk);
+            auto const conj_lkk = conj(lkk);
             for(I j0 = (kcol + 1) + j0_start; j0 < n; j0 += j0_inc)
             {
                 auto const j0k = idx2D(j0, kcol, lda);
@@ -193,7 +176,7 @@ __device__ static void potf2_simple(bool const is_upper, I const n, T* const A, 
                     {
                         auto const vi = A[idx2D(i, kcol, lda)];
                         auto const ij = idx2D(i, j, lda);
-                        A[ij] = A[ij] - vi * rocsolver_conj(vj);
+                        A[ij] = A[ij] - vi * conj(vj);
                     }
                 }
             }
@@ -270,7 +253,7 @@ __device__ static void potf2_simple(bool const is_upper, I const n, T* const A, 
                         auto const vi = A[idx2D(kcol, i, lda)];
                         auto const ij = idx2D(i, j, lda);
 
-                        A[ij] = A[ij] - rocsolver_conj(vi) * vj;
+                        A[ij] = A[ij] - conj(vi) * vj;
                     }
                 }
             }
@@ -370,7 +353,7 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
                                                            : idx_upper<rocblas_int>(i, j, n);
 
                 auto const aij = A[ij];
-                Ash[ij_packed] = (use_compute_lower) ? rocsolver_conj(aij) : aij;
+                Ash[ij_packed] = (use_compute_lower) ? conj(aij) : aij;
             };
         };
     }
@@ -410,7 +393,7 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
                                                            : idx_upper<rocblas_int>(i, j, n);
 
                 auto const aij_packed = Ash[ij_packed];
-                A[ij] = (use_compute_lower) ? rocsolver_conj(aij_packed) : aij_packed;
+                A[ij] = (use_compute_lower) ? conj(aij_packed) : aij_packed;
             };
         };
     }

--- a/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
+++ b/library/src/specialized/roclapack_trsm_specialized_kernels.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -714,19 +714,19 @@ rocblas_int rocsolver_trsm_blksize(const rocblas_int m, const rocblas_int n)
 
 /** This function determine workspace size for the internal trsm **/
 template <bool BATCHED, bool STRIDED, typename T>
-void rocsolver_trsm_mem(const rocblas_side side,
-                        const rocblas_operation trans,
-                        const rocblas_int m,
-                        const rocblas_int n,
-                        const rocblas_int batch_count,
-                        size_t* size_work1,
-                        size_t* size_work2,
-                        size_t* size_work3,
-                        size_t* size_work4,
-                        bool* optim_mem,
-                        bool inblocked,
-                        const rocblas_int inca,
-                        const rocblas_int incb)
+rocblas_status rocsolver_trsm_mem(const rocblas_side side,
+                                  const rocblas_operation trans,
+                                  const rocblas_int m,
+                                  const rocblas_int n,
+                                  const rocblas_int batch_count,
+                                  size_t* size_work1,
+                                  size_t* size_work2,
+                                  size_t* size_work3,
+                                  size_t* size_work4,
+                                  bool* optim_mem,
+                                  bool inblocked,
+                                  const rocblas_int inca,
+                                  const rocblas_int incb)
 {
     // always allocate all required memory for TRSM optimal performance
     *optim_mem = true;
@@ -737,7 +737,7 @@ void rocsolver_trsm_mem(const rocblas_side side,
         *size_work2 = 0;
         *size_work3 = 0;
         *size_work4 = 0;
-        return;
+        return rocblas_status_success;
     }
 
     rocblas_int mm = m;
@@ -757,7 +757,7 @@ void rocsolver_trsm_mem(const rocblas_side side,
             *size_work2 = 0;
             *size_work3 = 0;
             *size_work4 = 0;
-            return;
+            return rocblas_status_success;
         }
         else
             mm = m;
@@ -773,8 +773,8 @@ void rocsolver_trsm_mem(const rocblas_side side,
         mm = (m % 128 != 0) ? m : m + 1;
     }
 
-    rocblasCall_trsm_mem<BATCHED, T>(side, trans, mm, n, batch_count, size_work1, size_work2,
-                                     size_work3, size_work4);
+    return rocblasCall_trsm_mem<BATCHED, T>(side, trans, mm, n, batch_count, size_work1, size_work2,
+                                            size_work3, size_work4);
 }
 
 /** Internal TRSM (lower case):
@@ -1407,7 +1407,7 @@ inline rocblas_status rocsolver_trsm_upper(rocblas_handle handle,
 *************************************************************/
 
 #define INSTANTIATE_TRSM_MEM(BATCHED, STRIDED, T)                                    \
-    template void rocsolver_trsm_mem<BATCHED, STRIDED, T>(                           \
+    template rocblas_status rocsolver_trsm_mem<BATCHED, STRIDED, T>(                 \
         const rocblas_side side, const rocblas_operation trans, const rocblas_int m, \
         const rocblas_int n, const rocblas_int batch_count, size_t* size_work1,      \
         size_t* size_work2, size_t* size_work3, size_t* size_work4, bool* optim_mem, \


### PR DESCRIPTION
Here's a summary of the main changes I made and the rationale for each:

1. Removed explicit calls to rocblas_trsm. rocsolver_trsm is the entry point for all TRSM calls in rocSOLVER (and will itself call rocblas_trsm in many cases). If rocsolver_trsm is running slower than rocblas_trsm, we should tune rocsolver_trsm so that all functions that call TRSM will benefit.
2. Removed rocsolver_conj. We already have a conj method defined in rocblas_utility.hpp, so this method was redundant.
3. Removed lambda functions. The function bodies were short and simple enough that using lambda functions seemed just a tad excessive. It's not a big deal to me and can be reverted if needed.
4. Only use required amount of LDS. I also removed the assertion that it be less than the maximum amount of LDS, not because I don't think it's valuable, but I would prefer if it were queried from the device rather than hard-coded as a magic number. It might be something we can add to the ROCSOLVER_LAUNCH_KERNEL macro at a later date.