### PR TITLE
Cleanup for recursive Cholesky

### DIFF
--- a/library/src/include/ideal_sizes.hpp
+++ b/library/src/include/ideal_sizes.hpp
@@ -226,6 +226,16 @@
 
 /************************** potf2/potrf ***************************************
 *******************************************************************************/
+/*! \brief Determines the maximum size at which rocSOLVER can use the small-size POTF2
+    kernel.
+    \details
+    POTF2 will attempt to factorize a small symmetric matrix that can fit entirely
+    within the LDS share memory using compact storage.
+    The amount of LDS shared memory is assumed to be at least (64 * 1024) bytes. */
+#ifndef POTF2_MAX_SMALL_SIZE
+#define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 4) ? 180 : (sizeof(T) == 8) ? 127 : 90)
+#endif
+
 /*! \brief Determines the size of the leading block that is factorized at each step
     when using the blocked algorithm (POTRF). It also applies to the
     corresponding batched and strided-batched routines.*/
@@ -239,26 +249,19 @@
 
     \details POTRF will factorize blocks of POTRF_BLOCKSIZE columns at a time until
     the rest of the matrix has no more than POTRF_POTF2_SWITCHSIZE columns; at this point the last block,
-    if any, will be factorized with the unblocked algorithm (POTF2).*/
+    if any, will be factorized with the unblocked algorithm (POTF2). */
 #ifndef POTRF_POTF2_SWITCHSIZE
 #define POTRF_POTF2_SWITCHSIZE(T) POTRF_BLOCKSIZE(T)
 #endif
 
-/*! \brief Determines the maximum size at which rocSOLVER can use POTF2
-    \details 
-    POTF2 will attempt to factorize a small symmetric matrix that can fit entirely
-    within the LDS share memory using compact storage.  
-    The amount of LDS shared memory is assumed to be at least (64 * 1024) bytes. */
-#ifndef POTF2_MAX_SMALL_SIZE
-#define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 4) ? 180 : (sizeof(T) == 8) ? 127 : 90)
-#endif
-
-/*! \brief Determines the size at which recusive algorithm can terminate
-    \details 
-    Assume there is last level cache that is at least 8 MBytes, so terminate recursion
-    at this level.  */
-#ifndef POTRF_STOPPING_NB
-#define POTRF_STOPPING_NB(T) ((sizeof(T) == 4) ? 1408 : (sizeof(T) == 8) ? 1024 : 704)
+/*! \brief Determines the size at which rocSOLVER switches from
+    the recursive to the right-looking algorithm when executing POTRF. It also applies to the
+    corresponding batched and strided-batched routines.
+    \details POTRF will recursively divide the matrix into submatrices of size n/2 until
+    n/2 is less than POTRF_RECURSIVE_SWITCHSIZE; at this point the the submatrix will be
+    factorized with the right-looking algorithm (POTRF or POTF2). */
+#ifndef POTRF_RECURSIVE_SWITCHSIZE
+#define POTRF_RECURSIVE_SWITCHSIZE(T) ((sizeof(T) == 4) ? 1408 : (sizeof(T) == 8) ? 1024 : 704)
 #endif
 
 /************************** syevj/heevj ***************************************

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -333,11 +333,6 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
         auto const n2 = n / 2;
         auto const n1 = n - n2;
 
-        auto const A11_offset = idx2D(0, 0, lda);
-        auto const A21_offset = idx2D(n1, 0, lda);
-        auto const A12_offset = idx2D(0, n1, lda);
-        auto const A22_offset = idx2D(n1, n1, lda);
-
         if(uplo == rocblas_fill_upper)
         {
             // -------------------------------------------------

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -71,29 +71,29 @@ ROCSOLVER_KERNEL void
 }
 
 template <bool BATCHED, bool STRIDED, typename T>
-void rocsolver_potrf_rightlooking_getMemorySize(const rocblas_int n,
-                                                const rocblas_fill uplo,
-                                                const rocblas_int batch_count,
-                                                size_t* size_scalars,
-                                                size_t* size_work1,
-                                                size_t* size_work2,
-                                                size_t* size_work3,
-                                                size_t* size_work4,
-                                                size_t* size_pivots,
-                                                size_t* size_iinfo,
-                                                bool* optim_mem)
+void rocsolver_potrf_getMemorySize(const rocblas_int n,
+                                   const rocblas_fill uplo,
+                                   const rocblas_int batch_count,
+                                   size_t* size_scalars,
+                                   size_t* size_work1,
+                                   size_t* size_work2,
+                                   size_t* size_work3,
+                                   size_t* size_work4,
+                                   size_t* size_pivots,
+                                   size_t* size_iinfo,
+                                   bool* optim_mem)
 {
-    *size_scalars = 0;
-    *size_work1 = 0;
-    *size_work2 = 0;
-    *size_work3 = 0;
-    *size_work4 = 0;
-    *size_pivots = 0;
-    *size_iinfo = 0;
-    *optim_mem = true;
     // if quick return no need of workspace
     if(n == 0 || batch_count == 0)
     {
+        *size_scalars = 0;
+        *size_work1 = 0;
+        *size_work2 = 0;
+        *size_work3 = 0;
+        *size_work4 = 0;
+        *size_pivots = 0;
+        *size_iinfo = 0;
+        *optim_mem = true;
         return;
     }
 
@@ -108,11 +108,11 @@ void rocsolver_potrf_rightlooking_getMemorySize(const rocblas_int n,
         *size_iinfo = 0;
         *optim_mem = true;
     }
-    else
+    else if(n <= POTRF_RECURSIVE_SWITCHSIZE(T))
     {
-        rocblas_int const jb = nb;
-        size_t s1 = 0;
-        size_t s2 = 0;
+        // requirements for right-looking POTRF
+        rocblas_int jb = nb;
+        size_t s1, s2;
 
         // size to store info about positiveness of each subblock
         *size_iinfo = sizeof(rocblas_int) * batch_count;
@@ -136,371 +136,59 @@ void rocsolver_potrf_rightlooking_getMemorySize(const rocblas_int n,
 
         *size_work1 = std::max(s1, s2);
     }
-}
-
-template <bool BATCHED, bool STRIDED, typename T>
-void rocsolver_potrf_recursive_getMemorySize(const rocblas_int n,
-                                             const rocblas_fill uplo,
-                                             const rocblas_int batch_count,
-                                             size_t* size_scalars,
-                                             size_t* size_work1,
-                                             size_t* size_work2,
-                                             size_t* size_work3,
-                                             size_t* size_work4,
-                                             size_t* size_pivots,
-                                             size_t* size_iinfo,
-                                             bool* optim_mem)
-{
-    size_t lsize_scalars = 0;
-    size_t lsize_work1 = 0;
-    size_t lsize_work2 = 0;
-    size_t lsize_work3 = 0;
-    size_t lsize_work4 = 0;
-    size_t lsize_pivots = 0;
-    size_t lsize_iinfo = 0;
-
-    auto const nsmall = POTRF_BLOCKSIZE(T);
-    bool const is_nsmall = (n <= nsmall);
-    if(is_nsmall)
-    {
-        rocsolver_potf2_getMemorySize<T>(n, batch_count, &lsize_scalars, &lsize_work1, &lsize_pivots);
-
-        *size_scalars = std::max(*size_scalars, lsize_scalars);
-        *size_work1 = std::max(*size_work1, lsize_work1);
-        *size_work2 = std::max(*size_work2, lsize_work2);
-        *size_work3 = std::max(*size_work3, lsize_work3);
-        *size_work4 = std::max(*size_work4, lsize_work4);
-        *size_pivots = std::max(*size_pivots, lsize_pivots);
-        *size_iinfo = std::max(*size_iinfo, lsize_iinfo);
-    }
-    else if(n <= POTRF_STOPPING_NB(T))
-    {
-        rocsolver_potrf_rightlooking_getMemorySize<BATCHED, STRIDED, T>(
-            n, uplo, batch_count, &lsize_scalars, &lsize_work1, &lsize_work2, &lsize_work3,
-            &lsize_work4, &lsize_pivots, &lsize_iinfo, optim_mem);
-
-        *size_scalars = std::max(*size_scalars, lsize_scalars);
-        *size_work1 = std::max(*size_work1, lsize_work1);
-        *size_work2 = std::max(*size_work2, lsize_work2);
-        *size_work3 = std::max(*size_work3, lsize_work3);
-        *size_work4 = std::max(*size_work4, lsize_work4);
-        *size_pivots = std::max(*size_pivots, lsize_pivots);
-        *size_iinfo = std::max(*size_iinfo, lsize_iinfo);
-    }
     else
     {
+        // requirements for recursive POTRF
         auto const n2 = n / 2;
         auto const n1 = n - n2;
 
+        size_t w11 = 0, w12 = 0, w13 = 0;
+        size_t w21 = 0, w22 = 0, w23 = 0;
+        size_t w31 = 0, w32 = 0, w33 = 0;
+        size_t w41 = 0, w42 = 0, w43 = 0;
+        size_t p1 = 0, p2 = 0;
+        bool opt1 = false, opt2 = false, opt3 = false;
+        size_t unused;
+
+        // size to store info about positiveness of each subblock and submatrix
+        *size_iinfo = sizeof(rocblas_int) * 2 * batch_count;
+
+        // requirements for calling POTRF recursively on submatrices
+        rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n1, uplo, batch_count, size_scalars, &w11,
+                                                           &w21, &w31, &w41, &p1, &unused, &opt1);
+
+        rocsolver_potrf_getMemorySize<BATCHED, STRIDED, T>(n2, uplo, batch_count, &unused, &w12,
+                                                           &w22, &w32, &w42, &p2, &unused, &opt2);
+
+        // extra requirements for calling TRSM
         if(uplo == rocblas_fill_upper)
         {
-            // -----------------------------------------------
-            // (2) U11' * U12 = A12,     TRSM triangular solve
-            // or  U12 = A12/U11'
-            // -----------------------------------------------
-            auto const mm = n1;
-            auto const nn = n2;
-            rocsolver_trsm_mem<BATCHED, STRIDED, T>(
-                rocblas_side_left, rocblas_operation_conjugate_transpose, mm, nn, batch_count,
-                &lsize_work1, &lsize_work2, &lsize_work3, &lsize_work4, optim_mem);
-
-            *size_work1 = std::max(*size_work1, lsize_work1);
-            *size_work2 = std::max(*size_work2, lsize_work2);
-            *size_work3 = std::max(*size_work3, lsize_work3);
-            *size_work4 = std::max(*size_work4, lsize_work4);
+            rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_left,
+                                                    rocblas_operation_conjugate_transpose, n1, n2,
+                                                    batch_count, &w13, &w23, &w33, &w43, &opt3);
         }
         else
         {
-            // ------------------------------------------
-            // (2)  L21 * L11' = A21 or
-            //      L21 = A21 / L11'     TRSM triangular solve
-            // ------------------------------------------
-            auto const mm = n2;
-            auto const nn = n1;
-            rocsolver_trsm_mem<BATCHED, STRIDED, T>(
-                rocblas_side_right, rocblas_operation_conjugate_transpose, mm, nn, batch_count,
-                &lsize_work1, &lsize_work2, &lsize_work3, &lsize_work4, optim_mem);
-
-            *size_work1 = std::max(*size_work1, lsize_work1);
-            *size_work2 = std::max(*size_work2, lsize_work2);
-            *size_work3 = std::max(*size_work3, lsize_work3);
-            *size_work4 = std::max(*size_work4, lsize_work4);
+            rocsolver_trsm_mem<BATCHED, STRIDED, T>(rocblas_side_right,
+                                                    rocblas_operation_conjugate_transpose, n2, n1,
+                                                    batch_count, &w13, &w23, &w33, &w43, &opt3);
         }
 
-        {
-            auto const nn = n1;
-            rocsolver_potrf_recursive_getMemorySize<BATCHED, STRIDED, T>(
-                nn, uplo, batch_count, &lsize_scalars, &lsize_work1, &lsize_work2, &lsize_work3,
-                &lsize_work4, &lsize_pivots, &lsize_iinfo, optim_mem);
-
-            *size_scalars = std::max(*size_scalars, lsize_scalars);
-            *size_work1 = std::max(*size_work1, lsize_work1);
-            *size_work2 = std::max(*size_work2, lsize_work2);
-            *size_work3 = std::max(*size_work3, lsize_work3);
-            *size_work4 = std::max(*size_work4, lsize_work4);
-            *size_pivots = std::max(*size_pivots, lsize_pivots);
-            *size_iinfo = std::max(*size_iinfo, lsize_iinfo);
-        }
-
-        {
-            auto const nn = n2;
-            rocsolver_potrf_recursive_getMemorySize<BATCHED, STRIDED, T>(
-                nn, uplo, batch_count, &lsize_scalars, &lsize_work1, &lsize_work2, &lsize_work3,
-                &lsize_work4, &lsize_pivots, &lsize_iinfo, optim_mem);
-
-            *size_scalars = std::max(*size_scalars, lsize_scalars);
-            *size_work1 = std::max(*size_work1, lsize_work1);
-            *size_work2 = std::max(*size_work2, lsize_work2);
-            *size_work3 = std::max(*size_work3, lsize_work3);
-            *size_work4 = std::max(*size_work4, lsize_work4);
-            *size_pivots = std::max(*size_pivots, lsize_pivots);
-            *size_iinfo = std::max(*size_iinfo, lsize_iinfo);
-        }
+        *size_work1 = std::max({w11, w12, w13});
+        *size_work2 = std::max({w21, w22, w23});
+        *size_work3 = std::max({w31, w32, w33});
+        *size_work4 = std::max({w41, w42, w43});
+        *size_pivots = std::max(p1, p2);
+        *optim_mem = opt1 && opt2 && opt3;
     }
 }
 
-template <bool BATCHED, bool STRIDED, typename T, typename I, typename S, typename U>
-rocblas_status rocsolver_potrf_rightlooking_template(rocblas_handle handle,
-                                                     const rocblas_fill uplo,
-                                                     const I n,
-                                                     U A,
-                                                     const I shiftA,
-                                                     const I lda,
-                                                     const rocblas_stride strideA,
-                                                     I* info,
-                                                     const I batch_count,
-                                                     T* scalars,
-                                                     void* work1,
-                                                     void* work2,
-                                                     void* work3,
-                                                     void* work4,
-                                                     T* pivots,
-                                                     I* iinfo,
-                                                     bool optim_mem,
-                                                     I row_offset = 0)
-{
-    // quick return
-    if((batch_count == 0) || (n == 0))
-    {
-        return rocblas_status_success;
-    }
-
-    hipStream_t stream;
-    rocblas_get_stream(handle, &stream);
-
-    auto const blocksReset = (batch_count - 1) / BS1 + 1;
-    dim3 gridReset(blocksReset, 1, 1);
-    dim3 threads(BS1, 1, 1);
-
-    // if the matrix is small, use the unblocked (BLAS-levelII) variant of the
-    // algorithm
-    auto const nb = POTRF_BLOCKSIZE(T);
-    if(n <= nb)
-    {
-        return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info,
-                                           batch_count, scalars, (T*)work1, pivots);
-    }
-
-    // constants for rocblas functions calls
-    T t_one = 1;
-    S s_one = 1;
-    S s_minone = -1;
-
-    I jb = 0;
-    I j = 0;
-
-    // (TODO: When the matrix is detected to be non positive definite, we need to
-    //  prevent TRSM and HERK to modify further the input matrix; ideally with no
-    //  synchronizations.)
-
-    if(uplo == rocblas_fill_upper)
-    {
-        // Compute the Cholesky factorization A = U'*U.
-        while(j < n - POTRF_POTF2_SWITCHSIZE(T))
-        {
-            // Factor diagonal and subdiagonal blocks
-            jb = std::min(n - j, nb); // number of columns in the block
-            ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo, batch_count, 0);
-            rocsolver_potf2_template<T>(handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda,
-                                        strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
-
-            // test for non-positive-definiteness.
-            ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info,
-                                    j + row_offset, batch_count);
-
-            if(j + jb < n)
-            {
-                {
-                    auto const istat = rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                        rocblas_diagonal_non_unit, jb, (n - j - jb), A, shiftA + idx2D(j, j, lda),
-                        lda, strideA, A, shiftA + idx2D(j, j + jb, lda), lda, strideA, batch_count,
-                        optim_mem, work1, work2, work3, work4);
-                    if(istat != rocblas_status_success)
-                    {
-                        return (istat);
-                    }
-                }
-
-                {
-                    // update trailing submatrix
-                    auto const istat = rocblasCall_syrk_herk<BATCHED, T>(
-                        handle, uplo, rocblas_operation_conjugate_transpose, n - j - jb, jb,
-                        &s_minone, A, shiftA + idx2D(j, j + jb, lda), lda, strideA, &s_one, A,
-                        shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count);
-
-                    if(istat != rocblas_status_success)
-                    {
-                        return (istat);
-                    }
-                }
-            }
-            j += nb;
-        }
-    }
-    else
-    {
-        // Compute the Cholesky factorization A = L*L'.
-        while(j < n - POTRF_POTF2_SWITCHSIZE(T))
-        {
-            // Factor diagonal and subdiagonal blocks
-            jb = std::min(n - j, nb); // number of columns in the block
-            ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo, batch_count, 0);
-            rocsolver_potf2_template<T>(handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda,
-                                        strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
-
-            // test for non-positive-definiteness.
-            ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info,
-                                    j + row_offset, batch_count);
-
-            if(j + jb < n)
-            {
-                {
-                    auto const istat = rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                        handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
-                        rocblas_diagonal_non_unit, (n - j - jb), jb, A, shiftA + idx2D(j, j, lda),
-                        lda, strideA, A, shiftA + idx2D(j + jb, j, lda), lda, strideA, batch_count,
-                        optim_mem, work1, work2, work3, work4);
-
-                    if(istat != rocblas_status_success)
-                    {
-                        return (istat);
-                    }
-                }
-
-                {
-                    // update trailing submatrix
-                    auto const istat = rocblasCall_syrk_herk<BATCHED, T>(
-                        handle, uplo, rocblas_operation_none, n - j - jb, jb, &s_minone, A,
-                        shiftA + idx2D(j + jb, j, lda), lda, strideA, &s_one, A,
-                        shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count);
-
-                    if(istat != rocblas_status_success)
-                    {
-                        return (istat);
-                    }
-                }
-            }
-            j += nb;
-        }
-    }
-
-    // factor last block
-    if(j < n)
-    {
-        auto const nn = n - j;
-        bool const has_work = (nn >= 1);
-        if(has_work)
-        {
-            rocsolver_potf2_template<T>(handle, uplo, nn, A, shiftA + idx2D(j, j, lda), lda,
-                                        strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
-            ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info,
-                                    j + row_offset, batch_count);
-        }
-    }
-
-    return rocblas_status_success;
-}
-
-template <bool BATCHED, bool STRIDED, typename T>
-void rocsolver_potrf_getMemorySize(const rocblas_int n,
-                                   const rocblas_fill uplo,
-                                   const rocblas_int batch_count,
-                                   size_t* size_scalars,
-                                   size_t* size_work1,
-                                   size_t* size_work2,
-                                   size_t* size_work3,
-                                   size_t* size_work4,
-                                   size_t* size_pivots,
-                                   size_t* size_iinfo,
-                                   bool* optim_mem)
-{
-    *size_scalars = 0;
-    *size_work1 = 0;
-    *size_work2 = 0;
-    *size_work3 = 0;
-    *size_work4 = 0;
-    *size_pivots = 0;
-    *size_iinfo = 0;
-    *optim_mem = true;
-
-    // if quick return no need of workspace
-    if(n == 0 || batch_count == 0)
-    {
-        return;
-    }
-
-    size_t lsize_scalars = 0;
-    size_t lsize_work1 = 0;
-    size_t lsize_work2 = 0;
-    size_t lsize_work3 = 0;
-    size_t lsize_work4 = 0;
-    size_t lsize_pivots = 0;
-    size_t lsize_iinfo = std::max(1, batch_count) * sizeof(rocblas_int);
-
-    bool const use_recursive = (n > POTRF_STOPPING_NB(T));
-    if(use_recursive)
-    {
-        // -------------------
-        // recursive algorithm
-        // -------------------
-        rocsolver_potrf_recursive_getMemorySize<BATCHED, STRIDED, T>(
-            n, uplo, batch_count, &lsize_scalars, &lsize_work1, &lsize_work2, &lsize_work3,
-            &lsize_work4, &lsize_pivots, &lsize_iinfo, optim_mem);
-
-        *size_scalars = std::max(*size_scalars, lsize_scalars);
-        *size_work1 = std::max(*size_work1, lsize_work1);
-        *size_work2 = std::max(*size_work2, lsize_work2);
-        *size_work3 = std::max(*size_work3, lsize_work3);
-        *size_work4 = std::max(*size_work4, lsize_work4);
-        *size_pivots = std::max(*size_pivots, lsize_pivots);
-        *size_iinfo = std::max(*size_iinfo, lsize_iinfo);
-    }
-    else
-    {
-        // -----------------------
-        // right-looking algorithm
-        // -----------------------
-        rocsolver_potrf_rightlooking_getMemorySize<BATCHED, STRIDED, T>(
-            n, uplo, batch_count, &lsize_scalars, &lsize_work1, &lsize_work2, &lsize_work3,
-            &lsize_work4, &lsize_pivots, &lsize_iinfo, optim_mem);
-
-        *size_scalars = std::max(*size_scalars, lsize_scalars);
-        *size_work1 = std::max(*size_work1, lsize_work1);
-        *size_work2 = std::max(*size_work2, lsize_work2);
-        *size_work3 = std::max(*size_work3, lsize_work3);
-        *size_work4 = std::max(*size_work4, lsize_work4);
-        *size_pivots = std::max(*size_pivots, lsize_pivots);
-        *size_iinfo = std::max(*size_iinfo, lsize_iinfo);
-    }
-}
-
-template <bool BATCHED, bool STRIDED, typename T, typename I, typename S, typename U>
+template <bool BATCHED, bool STRIDED, typename T, typename I, typename U>
 rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
                                                   const rocblas_fill uplo,
                                                   const I n,
                                                   U A,
-                                                  const I shiftA,
+                                                  const rocblas_stride shiftA,
                                                   const I lda,
                                                   const rocblas_stride strideA,
                                                   I* info,
@@ -512,19 +200,30 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
                                                   void* work4,
                                                   T* pivots,
                                                   I* iinfo,
-                                                  bool optim_mem,
-                                                  const I row_offset)
+                                                  bool optim_mem)
 {
+    ROCSOLVER_ENTER("potrf_recursive", "uplo:", uplo, "n:", n, "shiftA:", shiftA, "lda:", lda,
+                    "bc:", batch_count);
+    using S = decltype(std::real(T{}));
+
     // quick return
-    if((n == 0) || (batch_count == 0))
-    {
+    if(n == 0)
         return rocblas_status_success;
+
+    // -------------------------------------------------
+    // UNBLOCKED ALGORITHM FOR SMALL MATRICES
+    // -------------------------------------------------
+    I nb = POTRF_BLOCKSIZE(T);
+    if(n <= POTRF_POTF2_SWITCHSIZE(T))
+    {
+        return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info,
+                                           batch_count, scalars, (T*)work1, pivots);
     }
 
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    auto const blocksReset = (batch_count - 1) / BS1 + 1;
+    rocblas_int blocksReset = (batch_count - 1) / BS1 + 1;
     dim3 gridReset(blocksReset, 1, 1);
     dim3 threads(BS1, 1, 1);
 
@@ -533,46 +232,99 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
     S s_one = 1;
     S s_minone = -1;
 
-    auto const nsmall = POTRF_BLOCKSIZE(T);
-    bool const is_nsmall = (n <= nsmall);
+    // (TODO: When the matrix is detected to be non positive definite, we need to
+    //  prevent TRSM and HERK to modify further the input matrix; ideally with no
+    //  synchronizations.)
 
-    // ----------------------------------------------
-    // terminate recursion when n is considered small
-    // ----------------------------------------------
-    if(is_nsmall)
+    // -------------------------------------------------
+    // RIGHT-LOOKING ALGORITHM FOR MEDIUM MATRICES
+    // -------------------------------------------------
+    if(n <= POTRF_RECURSIVE_SWITCHSIZE(T))
     {
-        if(iinfo != nullptr)
+        I jb, j = 0;
+
+        if(uplo == rocblas_fill_upper)
         {
-            ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo, batch_count, 0);
+            // Compute the Cholesky factorization A = U'*U.
+            while(j < n - POTRF_POTF2_SWITCHSIZE(T))
+            {
+                // Factor diagonal and subdiagonal blocks
+                jb = std::min(n - j, nb); // number of columns in the block
+                ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo,
+                                        batch_count, 0);
+                rocsolver_potf2_template<T>(handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda,
+                                            strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
+
+                // test for non-positive-definiteness.
+                ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info,
+                                        j, batch_count);
+
+                if(j + jb < n)
+                {
+                    // update trailing submatrix
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, jb, (n - j - jb), A, shiftA + idx2D(j, j, lda),
+                        lda, strideA, A, shiftA + idx2D(j, j + jb, lda), lda, strideA, batch_count,
+                        optim_mem, work1, work2, work3, work4);
+
+                    rocblasCall_syrk_herk<BATCHED, T>(
+                        handle, uplo, rocblas_operation_conjugate_transpose, n - j - jb, jb,
+                        &s_minone, A, shiftA + idx2D(j, j + jb, lda), lda, strideA, &s_one, A,
+                        shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count);
+                }
+                j += nb;
+            }
+        }
+        else
+        {
+            // Compute the Cholesky factorization A = L*L'.
+            while(j < n - POTRF_POTF2_SWITCHSIZE(T))
+            {
+                // Factor diagonal and subdiagonal blocks
+                jb = std::min(n - j, nb); // number of columns in the block
+                ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo,
+                                        batch_count, 0);
+                rocsolver_potf2_template<T>(handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda,
+                                            strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
+
+                // test for non-positive-definiteness.
+                ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info,
+                                        j, batch_count);
+
+                if(j + jb < n)
+                {
+                    // update trailing submatrix
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, (n - j - jb), jb, A, shiftA + idx2D(j, j, lda),
+                        lda, strideA, A, shiftA + idx2D(j + jb, j, lda), lda, strideA, batch_count,
+                        optim_mem, work1, work2, work3, work4);
+
+                    rocblasCall_syrk_herk<BATCHED, T>(
+                        handle, uplo, rocblas_operation_none, n - j - jb, jb, &s_minone, A,
+                        shiftA + idx2D(j + jb, j, lda), lda, strideA, &s_one, A,
+                        shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count);
+                }
+                j += nb;
+            }
         }
 
-        auto const istat = rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA,
-                                                       (iinfo != nullptr) ? iinfo : info,
-                                                       batch_count, scalars, (T*)work1, pivots);
-
-        // test for non-positive-definiteness.
-        if(iinfo != nullptr)
+        // factor last block
+        if(j < n)
         {
-            I const j = 0;
-            ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info,
-                                    j + row_offset, batch_count);
+            rocsolver_potf2_template<T>(handle, uplo, n - j, A, shiftA + idx2D(j, j, lda), lda,
+                                        strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
+            ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info, j,
+                                    batch_count);
         }
 
-        return (istat);
+        return rocblas_status_success;
     }
-    else if(n <= POTRF_STOPPING_NB(T))
-    {
-        if(iinfo != nullptr)
-        {
-            ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo, batch_count, 0);
-        }
 
-        auto const istat = rocsolver_potrf_rightlooking_template<BATCHED, STRIDED, T, I, S, U>(
-            handle, uplo, n, A, shiftA, lda, strideA, info, batch_count, scalars, work1, work2,
-            work3, work4, pivots, (iinfo != nullptr) ? iinfo : info, optim_mem, row_offset);
-
-        return (istat);
-    }
+    // -------------------------------------------------
+    // RECURSIVE ALGORITHM FOR LARGE MATRICES
+    // -------------------------------------------------
     else
     {
         auto const n2 = n / 2;
@@ -583,97 +335,7 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
         auto const A12_offset = idx2D(0, n1, lda);
         auto const A22_offset = idx2D(n1, n1, lda);
 
-        if(uplo == rocblas_fill_lower)
-        {
-            // ------------------------------------------------
-            // [A11  A21'] = [L11   0  ] * [L11'  L21']
-            // [A21  A22 ]   [L21   L22]   [0     L22']
-            //
-            // where A11 is n1 by n1,  A22 is n2 by n2,  n == (n1 + n2)
-            //
-            // (1)  A11 = L11 * L11'     Cholesky factorization
-            //
-            // (2)  L21 * L11' = A21 or
-            //      L21 = A21 / L11'     TRSM triangular solve
-            //
-            // (3)  L22 * L22' = (A22 - L21 * L21')
-            // or
-            // (3a)  A22 <-  A22 - L21 * L21',   SYRK
-            // (3b)  L22 * L22' = A22    Cholesky factorization
-            // ------------------------------------------------
-
-            // --------------------
-            // (1)  A11 = L11 * L11'
-            // --------------------
-            {
-                auto const nn = n1;
-
-                I const j = 0;
-                auto const istat = rocsolver_potrf_recursive_template<BATCHED, STRIDED, T, I, S, U>(
-                    handle, uplo, nn, A, shiftA + A11_offset, lda, strideA, info, batch_count,
-                    scalars, work1, work2, work3, work4, pivots, iinfo, optim_mem, row_offset + j);
-
-                if(istat != rocblas_status_success)
-                {
-                    return (istat);
-                }
-            }
-
-            // -------------------
-            // (2) L21 = A21 / L11'
-            // -------------------
-
-            {
-                // update trailing submatrix
-                auto const mm = n2;
-                auto const nn = n1;
-                auto const istat = rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, mm, nn, A, shiftA + A11_offset, lda, strideA, A,
-                    shiftA + A21_offset, lda, strideA, batch_count, optim_mem, work1, work2, work3,
-                    work4);
-
-                if(istat != rocblas_status_success)
-                {
-                    return (istat);
-                }
-            }
-
-            // --------------------------------------
-            // (3a)  A22 <-  A22 - L21 * L21',   SYRK
-            // --------------------------------------
-            {
-                auto const nn = n2;
-                auto const kk = n1;
-
-                auto const istat = rocblasCall_syrk_herk<BATCHED, T>(
-                    handle, uplo, rocblas_operation_none, nn, kk, &s_minone, A, shiftA + A21_offset,
-                    lda, strideA, &s_one, A, shiftA + A22_offset, lda, strideA, batch_count);
-
-                if(istat != rocblas_status_success)
-                {
-                    return (istat);
-                }
-            }
-
-            // ------------------------------------------------
-            // (3b)  L22 * L22' = A22    Cholesky factorization
-            // ------------------------------------------------
-            {
-                auto const nn = n2;
-                auto const j = n1;
-
-                auto const istat = rocsolver_potrf_recursive_template<BATCHED, STRIDED, T, I, S, U>(
-                    handle, uplo, nn, A, shiftA + A22_offset, lda, strideA, info, batch_count,
-                    scalars, work1, work2, work3, work4, pivots, iinfo, optim_mem, row_offset + j);
-
-                if(istat != rocblas_status_success)
-                {
-                    return (istat);
-                }
-            }
-        }
-        else
+        if(uplo == rocblas_fill_upper)
         {
             // -------------------------------------------------
             // A = U' * U
@@ -681,92 +343,70 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
             // [A12' A22]   [ U12'  U22']   [0    U22]
             //
             // where A11 is n1 by n1,  A22 is n2 by n2,  n == (n1 + n2)
-            //
-            // (1) A11 = U11' * U11,     Cholesky factorization
-            //
-            // (2) U11' * U12 = A12,     TRSM triangular solve
-            // or  U12 = A12/U11'
-            //
-            // (3) U22' * U22 = (A22 - U12' * U12]
-            // or
-            // (3a)  A22 <- A22 - U12' * U12     SYRK
-            // (3b)  U22' * U22 = A22    Cholesky factorization
             // -------------------------------------------------
 
-            // -------------------------------------
-            // (1) A11 = U11' * U11,     Cholesky factorization
-            // -------------------------------------
-            {
-                auto const nn = n1;
-                I const j = 0;
-                rocblas_status const istat
-                    = rocsolver_potrf_recursive_template<BATCHED, STRIDED, T, I, S, U>(
-                        handle, uplo, nn, A, shiftA + A11_offset, lda, strideA, info, batch_count,
-                        scalars, work1, work2, work3, work4, pivots, iinfo, optim_mem,
-                        row_offset + j);
+            // find U11 given A11 = U11' * U11
+            ROCBLAS_CHECK(rocsolver_potrf_recursive_template<BATCHED, STRIDED, T>(
+                handle, uplo, n1, A, shiftA, lda, strideA, info, batch_count, scalars, work1, work2,
+                work3, work4, pivots, iinfo, optim_mem));
 
-                if(istat != rocblas_status_success)
-                {
-                    return (istat);
-                }
-            }
+            // find U12 given A12 = U11' * U12
+            ROCBLAS_CHECK(rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_diagonal_non_unit, n1, n2, A, shiftA, lda, strideA, A,
+                shiftA + idx2D(0, n1, lda), lda, strideA, batch_count, optim_mem, work1, work2,
+                work3, work4));
 
-            // -----------------------------------------------
-            // (2) U11' * U12 = A12,     TRSM triangular solve
-            // or  U12 = A12/U11'
-            // -----------------------------------------------
-            {
-                auto const mm = n1;
-                auto const nn = n2;
-                auto const istat = rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, mm, nn, A, shiftA + A11_offset, lda, strideA, A,
-                    shiftA + A12_offset, lda, strideA, batch_count, optim_mem, work1, work2, work3,
-                    work4);
+            // update A22 as A22 - U12' * U12
+            ROCBLAS_CHECK(rocblasCall_syrk_herk<BATCHED, T>(
+                handle, uplo, rocblas_operation_conjugate_transpose, n2, n1, &s_minone, A,
+                shiftA + idx2D(0, n1, lda), lda, strideA, &s_one, A, shiftA + idx2D(n1, n1, lda),
+                lda, strideA, batch_count));
 
-                if(istat != rocblas_status_success)
-                {
-                    return (istat);
-                }
-            }
-
-            // ---------------------------------------
-            // (3a)  A22 <- A22 - U12' * U12     SYRK
-            // ---------------------------------------
-            {
-                auto const nn = n2;
-                auto const kk = n1;
-                auto const istat = rocblasCall_syrk_herk<BATCHED, T>(
-                    handle, uplo, rocblas_operation_conjugate_transpose, nn, kk, &s_minone, A,
-                    shiftA + A12_offset, lda, strideA, &s_one, A, shiftA + A22_offset, lda, strideA,
-                    batch_count);
-
-                if(istat != rocblas_status_success)
-                {
-                    return (istat);
-                }
-            }
-
-            // -------------------------------------------------
-            // (3b)  U22' * U22 = A22    Cholesky factorization
-            // -------------------------------------------------
-            {
-                auto const nn = n2;
-                auto const j = n1;
-                //
-                auto const istat = rocsolver_potrf_recursive_template<BATCHED, STRIDED, T, I, S, U>(
-                    handle, uplo, nn, A, shiftA + A22_offset, lda, strideA, info, batch_count,
-                    scalars, work1, work2, work3, work4, pivots, iinfo, optim_mem, row_offset + j);
-
-                if(istat != rocblas_status_success)
-                {
-                    return (istat);
-                }
-            }
+            // find U22 given A22 = U22' * U22
+            ROCBLAS_CHECK(rocsolver_potrf_recursive_template<BATCHED, STRIDED, T>(
+                handle, uplo, n2, A, shiftA + idx2D(n1, n1, lda), lda, strideA, iinfo, batch_count,
+                scalars, work1, work2, work3, work4, pivots, iinfo + batch_count, optim_mem));
+            ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info, n1,
+                                    batch_count);
         }
-    }
+        else
+        {
+            // ------------------------------------------------
+            // A = L * L'
+            // [A11  A21'] = [L11   0  ] * [L11'  L21']
+            // [A21  A22 ]   [L21   L22]   [0     L22']
+            //
+            // where A11 is n1 by n1,  A22 is n2 by n2,  n == (n1 + n2)
+            // ------------------------------------------------
 
-    return rocblas_status_success;
+            // find L11 given A11 = L11 * L11'
+            ROCBLAS_CHECK(rocsolver_potrf_recursive_template<BATCHED, STRIDED, T>(
+                handle, uplo, n1, A, shiftA, lda, strideA, info, batch_count, scalars, work1, work2,
+                work3, work4, pivots, iinfo, optim_mem));
+
+            // find L21 given A21 = L21 * L11'
+            ROCBLAS_CHECK(rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
+                rocblas_diagonal_non_unit, n2, n1, A, shiftA, lda, strideA, A,
+                shiftA + idx2D(n1, 0, lda), lda, strideA, batch_count, optim_mem, work1, work2,
+                work3, work4));
+
+            // update A22 as A22 - L21 * L21'
+            ROCBLAS_CHECK(rocblasCall_syrk_herk<BATCHED, T>(
+                handle, uplo, rocblas_operation_none, n2, n1, &s_minone, A, shiftA + idx2D(n1, 0, lda),
+                lda, strideA, &s_one, A, shiftA + idx2D(n1, n1, lda), lda, strideA, batch_count));
+
+            // find L22 given A22 = L22 * L22'
+            ROCBLAS_CHECK(rocsolver_potrf_recursive_template<BATCHED, STRIDED, T>(
+                handle, uplo, n2, A, shiftA + idx2D(n1, n1, lda), lda, strideA, iinfo, batch_count,
+                scalars, work1, work2, work3, work4, pivots, iinfo + batch_count, optim_mem));
+            ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info, n1,
+                                    batch_count);
+        }
+
+        return rocblas_status_success;
+    }
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
@@ -795,39 +435,28 @@ rocblas_status rocsolver_potrf_template(rocblas_handle handle,
     if(batch_count == 0)
         return rocblas_status_success;
 
-    // quick return
-    if(n == 0)
-        return rocblas_status_success;
-
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    auto const blocksReset = (batch_count - 1) / BS1 + 1;
+    rocblas_int blocksReset = (batch_count - 1) / BS1 + 1;
     dim3 gridReset(blocksReset, 1, 1);
     dim3 threads(BS1, 1, 1);
 
     // info=0 (starting with a positive definite matrix)
     ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, info, batch_count, 0);
 
+    // quick return
+    if(n == 0)
+        return rocblas_status_success;
+
+    // everything must be executed with scalars on the host
     rocblas_pointer_mode old_mode;
     rocblas_get_pointer_mode(handle, &old_mode);
     rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
 
-    rocblas_status istat = rocblas_status_success;
-    bool const use_recursive = (n > POTRF_STOPPING_NB(T));
-    if(use_recursive)
-    {
-        rocblas_int const row_offset = 0;
-        istat = rocsolver_potrf_recursive_template<BATCHED, STRIDED, T, rocblas_int, S, U>(
-            handle, uplo, n, A, shiftA, lda, strideA, info, batch_count, scalars, work1, work2,
-            work3, work4, pivots, iinfo, optim_mem, row_offset);
-    }
-    else
-    {
-        istat = rocsolver_potrf_rightlooking_template<BATCHED, STRIDED, T, rocblas_int, S, U>(
-            handle, uplo, n, A, shiftA, lda, strideA, info, batch_count, scalars, work1, work2,
-            work3, work4, pivots, iinfo, optim_mem);
-    }
+    rocblas_status istat = rocsolver_potrf_recursive_template<BATCHED, STRIDED, T>(
+        handle, uplo, n, A, shiftA, lda, strideA, info, batch_count, scalars, work1, work2, work3,
+        work4, pivots, iinfo, optim_mem);
 
     rocblas_set_pointer_mode(handle, old_mode);
     return istat;

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -252,8 +252,9 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
                 jb = std::min(n - j, nb); // number of columns in the block
                 ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo,
                                         batch_count, 0);
-                rocsolver_potf2_template<T>(handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda,
-                                            strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
+                ROCBLAS_CHECK(rocsolver_potf2_template<T>(
+                    handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda, strideA, iinfo,
+                    batch_count, scalars, (T*)work1, pivots));
 
                 // test for non-positive-definiteness.
                 ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info,
@@ -262,16 +263,16 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
                 if(j + jb < n)
                 {
                     // update trailing submatrix
-                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                    ROCBLAS_CHECK(rocsolver_trsm_upper<BATCHED, STRIDED, T>(
                         handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
                         rocblas_diagonal_non_unit, jb, (n - j - jb), A, shiftA + idx2D(j, j, lda),
                         lda, strideA, A, shiftA + idx2D(j, j + jb, lda), lda, strideA, batch_count,
-                        optim_mem, work1, work2, work3, work4);
+                        optim_mem, work1, work2, work3, work4));
 
-                    rocblasCall_syrk_herk<BATCHED, T>(
+                    ROCBLAS_CHECK(rocblasCall_syrk_herk<BATCHED, T>(
                         handle, uplo, rocblas_operation_conjugate_transpose, n - j - jb, jb,
                         &s_minone, A, shiftA + idx2D(j, j + jb, lda), lda, strideA, &s_one, A,
-                        shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count);
+                        shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count));
                 }
                 j += nb;
             }
@@ -285,8 +286,9 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
                 jb = std::min(n - j, nb); // number of columns in the block
                 ROCSOLVER_LAUNCH_KERNEL(reset_info, gridReset, threads, 0, stream, iinfo,
                                         batch_count, 0);
-                rocsolver_potf2_template<T>(handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda,
-                                            strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
+                ROCBLAS_CHECK(rocsolver_potf2_template<T>(
+                    handle, uplo, jb, A, shiftA + idx2D(j, j, lda), lda, strideA, iinfo,
+                    batch_count, scalars, (T*)work1, pivots));
 
                 // test for non-positive-definiteness.
                 ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info,
@@ -295,16 +297,16 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
                 if(j + jb < n)
                 {
                     // update trailing submatrix
-                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                    ROCBLAS_CHECK(rocsolver_trsm_lower<BATCHED, STRIDED, T>(
                         handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
                         rocblas_diagonal_non_unit, (n - j - jb), jb, A, shiftA + idx2D(j, j, lda),
                         lda, strideA, A, shiftA + idx2D(j + jb, j, lda), lda, strideA, batch_count,
-                        optim_mem, work1, work2, work3, work4);
+                        optim_mem, work1, work2, work3, work4));
 
-                    rocblasCall_syrk_herk<BATCHED, T>(
+                    ROCBLAS_CHECK(rocblasCall_syrk_herk<BATCHED, T>(
                         handle, uplo, rocblas_operation_none, n - j - jb, jb, &s_minone, A,
                         shiftA + idx2D(j + jb, j, lda), lda, strideA, &s_one, A,
-                        shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count);
+                        shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count));
                 }
                 j += nb;
             }
@@ -313,8 +315,9 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
         // factor last block
         if(j < n)
         {
-            rocsolver_potf2_template<T>(handle, uplo, n - j, A, shiftA + idx2D(j, j, lda), lda,
-                                        strideA, iinfo, batch_count, scalars, (T*)work1, pivots);
+            ROCBLAS_CHECK(rocsolver_potf2_template<T>(handle, uplo, n - j, A,
+                                                      shiftA + idx2D(j, j, lda), lda, strideA, iinfo,
+                                                      batch_count, scalars, (T*)work1, pivots));
             ROCSOLVER_LAUNCH_KERNEL(chk_positive<U>, gridReset, threads, 0, stream, iinfo, info, j,
                                     batch_count);
         }

--- a/library/src/lapack/roclapack_potrf.hpp
+++ b/library/src/lapack/roclapack_potrf.hpp
@@ -204,7 +204,7 @@ rocblas_status rocsolver_potrf_recursive_template(rocblas_handle handle,
                                                   const I row_offset = 0)
 {
     ROCSOLVER_ENTER("potrf_recursive", "uplo:", uplo, "n:", n, "shiftA:", shiftA, "lda:", lda,
-                    "bc:", batch_count);
+                    "bc:", batch_count, "row_offset:", row_offset);
     using S = decltype(std::real(T{}));
 
     // quick return


### PR DESCRIPTION
Main changes:
- Renamed POTRF_STOPPING_NB to POTRF_RECURSIVE_SWITCHSIZE and updated documentation.
- Combined potrf_recursive_getMemorySize and potrf_rightlooking_getMemorySize into potrf_getMemorySize. I reverted the code for potrf_rightlooking_getMemorySize to how it is in develop.
- Combined potrf_rightlooking_template into potrf_recursive_template. I reverted the code for potrf_rightlooking_template to how it is in develop. I also trimmed the comments and updated the code style for potrf_recursive_template.